### PR TITLE
fix #1

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMMetricsSender.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMMetricsSender.java
@@ -84,6 +84,10 @@ public class JVMMetricsSender implements BootService, Runnable, GRPCChannelListe
                 }
             } catch (Throwable t) {
                 LOGGER.error(t, "send JVM metrics to Collector fail.");
+                Channel channel = ServiceManager.INSTANCE.findService(GRPCChannelManager.class).getChannel();
+                if (channel != null && channel.getState(true) == io.grpc.ConnectivityState.CONNECTED) {
+                    statusChanged(GRPCChannelStatus.DISCONNECT);
+                }
             }
         }
     }


### PR DESCRIPTION
1. 在JVMMetricsSender类的run方法中增加断开重连逻辑