### PR TITLE
fix #1/文件真多

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMMetricsSender.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/jvm/JVMMetricsSender.java
@@ -81,6 +81,13 @@ public class JVMMetricsSender implements BootService, Runnable, GRPCChannelListe
                     Commands commands = stub.withDeadlineAfter(GRPC_UPSTREAM_TIMEOUT, TimeUnit.SECONDS)
                                             .collect(builder.build());
                     ServiceManager.INSTANCE.findService(CommandService.class).receiveCommand(commands);
+                } catch (Throwable t) {
+                    reportError();
+                    LOGGER.error(t, "send JVM metrics to Collector fail.");
+                }
+            } catch (Throwable t) {
+                LOGGER.error(t, "send JVM metrics to Collector fail.");
+                    ServiceManager.INSTANCE.findService(CommandService.class).receiveCommand(commands);
                 }
             } catch (Throwable t) {
                 LOGGER.error(t, "send JVM metrics to Collector fail.");
@@ -107,3 +114,7 @@ public class JVMMetricsSender implements BootService, Runnable, GRPCChannelListe
 
     }
 }
+    private void reportError() {
+        status = GRPCChannelStatus.DISCONNECT;
+        ServiceManager.INSTANCE.findService(GRPCChannelManager.class).statusChanged(status);
+    }


### PR DESCRIPTION
1. 在JVMMetricsSender类的run方法中添加异常捕获，并调用reportError方法报告错误。
2. 新增reportError方法，用于更改状态为断开并通知服务管理器状态变化。